### PR TITLE
adding 2 more finders

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -54,10 +54,14 @@ p. Then your document will have the @tags@ and @tags_array@ getter and setter. @
 
 h2. Finding Objects by Tag
 
-p. Tagged models get a scope called @tagged_with@:
+p. Tagged models get a scope called @tagged_with@, @tagged_with_all@, and @tagged_with_any@:
 
 bc.. MyModel.tagged_with('foo')
 MyModel.published.tagged_with('foo').count
+MyModel.tagged_with_all('foo', 'bar')
+MyModel.tagged_with_all(['foo', 'bar'])
+MyModel.tagged_with_any('foo', 'bar')
+MyModel.tagged_with_any(['foo', 'bar'])
 
 h2. Tags Indexing
 

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -38,6 +38,14 @@ module Mongoid::Taggable
       self.any_in(:tags_array => [tag])
     end
 
+    def tagged_with_all(*tags)
+      self.all_in(:tags_array => tags.flatten)
+    end
+    
+    def tagged_with_any(*tags)
+      self.any_in(:tags_array => tags.flatten)
+    end
+
     def tags
       db = Mongoid::Config.master
       db.collection(tags_index_collection).find.to_a.map{ |r| r["_id"] }

--- a/spec/mongoid/taggable_spec.rb
+++ b/spec/mongoid/taggable_spec.rb
@@ -21,10 +21,49 @@ end
 
 describe Mongoid::Taggable do
 
-  context "finding by tag" do
-    it "locates tagged objects" do
-      m = MyModel.create!(:tags => "interesting,stuff")
-      MyModel.tagged_with('interesting').include?(m).should be_true
+  context "finding" do
+    let(:model){MyModel.create!(:tags => "interesting,stuff,good,bad")}
+    context "by tagged_with" do
+      let(:models){MyModel.tagged_with('interesting')}
+      it "locates tagged objects" do
+        models.include?(model).should be_true
+      end
+    end
+    context "by tagged_with_all using an array" do
+      let(:models){MyModel.tagged_with_all(['interesting', 'good'])}
+      it "locates tagged objects" do
+        models.include?(model).should be_true
+      end
+    end
+    context "by tagged_with_all using strings" do
+      let(:models){MyModel.tagged_with_all('interesting', 'good')}
+      it "locates tagged objects" do
+        models.include?(model).should be_true
+      end
+    end
+    context "by tagged_with_all when tag not included" do
+      let(:models){MyModel.tagged_with_all('interesting', 'good', 'mcdonalds')}
+      it "locates tagged objects" do
+        models.include?(model).should be_false
+      end
+    end
+    context "by tagged_with_any using an array" do
+      let(:models){MyModel.tagged_with_any(['interesting', 'mcdonalds'])}
+      it "locates tagged objects" do
+        models.include?(model).should be_true
+      end
+    end
+    context "by tagged_with_any using strings" do
+      let(:models){MyModel.tagged_with_any('interesting', 'mcdonalds')}
+      it "locates tagged objects" do
+        models.include?(model).should be_true
+      end
+    end
+    context "by tagged_with_any when tag not included" do
+      let(:models){MyModel.tagged_with_any('hardees', 'wendys', 'mcdonalds')}
+      it "locates tagged objects" do
+        models.include?(model).should be_false
+      end
     end
   end
 


### PR DESCRIPTION
We needed another finder that found documents that matched all tags not just one of them so I added a method for tagged_with_all, and while doing so made tagged_with_any that allows passing more than one tag, where as the tagged_with method only allowed one tag.  I didn't want to remove/change tagged_with but tagged_with_any does the same thing as tagged_with, it just allows more than one tag.
