### PR TITLE
updated indexing to work with Mongoid 3.0.0RC

### DIFF
--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -104,7 +104,7 @@ module Mongoid::Taggable
         return count;
       }"
 
-     self.collection.master.map_reduce(map, reduce, :out => tags_index_collection_name)
+     self.master.collection.map_reduce(map, reduce, :out => tags_index_collection_name)
     end
   end
 

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -78,7 +78,7 @@ module Mongoid::Taggable
     end
 
     def tags_index_collection
-      @@tags_index_collection ||= Mongoid::Collection.new(self, tags_index_collection_name)
+      @@tags_index_collection ||= Mongoid::Collections::Master.new(self, tags_index_collection_name)
     end
 
     def save_tags_index!

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -51,13 +51,13 @@ module Mongoid::Taggable
     end
 
     def tags
-      tags_index_collection.find.to_a.map{ |r| r["_id"] }
+      tags_index_collection.master.find.to_a.map{ |r| r["_id"] }
     end
 
     # retrieve the list of tags with weight (i.e. count), this is useful for
     # creating tag clouds
     def tags_with_weight
-      tags_index_collection.find.to_a.map{ |r| [r["_id"], r["value"]] }
+      tags_index_collection.master.find.to_a.map{ |r| [r["_id"], r["value"]] }
     end
 
     def disable_tags_index!
@@ -104,7 +104,7 @@ module Mongoid::Taggable
         return count;
       }"
 
-     self.collection.map_reduce(map, reduce, :out => tags_index_collection_name)
+     self.collection.master.map_reduce(map, reduce, :out => tags_index_collection_name)
     end
   end
 

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -78,7 +78,7 @@ module Mongoid::Taggable
     end
 
     def tags_index_collection
-      @@tags_index_collection ||= Mongoid::Collections::Master.new(self, tags_index_collection_name)
+      @@tags_index_collection ||= Mongoid::Collection.new(self, tags_index_collection_name)
     end
 
     def save_tags_index!

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -16,7 +16,7 @@ module Mongoid::Taggable
   def self.included(base)
     # create fields for tags and index it
     base.field :tags_array, :type => Array, :default => []
-    base.index [['tags_array', Mongo::ASCENDING]]
+    base.index 'tags_array' => 1
 
     # add callback to save tags index
     base.after_save do |document|

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -51,13 +51,13 @@ module Mongoid::Taggable
     end
 
     def tags
-      tags_index_collection.master.find.to_a.map{ |r| r["_id"] }
+      tags_index_collection.find.to_a.map{ |r| r["_id"] }
     end
 
     # retrieve the list of tags with weight (i.e. count), this is useful for
     # creating tag clouds
     def tags_with_weight
-      tags_index_collection.master.find.to_a.map{ |r| [r["_id"], r["value"]] }
+      tags_index_collection.find.to_a.map{ |r| [r["_id"], r["value"]] }
     end
 
     def disable_tags_index!
@@ -104,7 +104,7 @@ module Mongoid::Taggable
         return count;
       }"
 
-     self.collection.master.map_reduce(map, reduce, :out => tags_index_collection_name)
+     self.collection.map_reduce(map, reduce, :out => tags_index_collection_name)
     end
   end
 


### PR DESCRIPTION
The indexing has changed in the recent mongoid gem update. http://mongoid.org/en/mongoid/docs/indexing.html

Mongo::ASCENDING no longer works, instead is replaced with -1 or 1 for direction.
