### PR TITLE
Made indexing tags substantially faster. Also added "find related" documents based on tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,8 @@ group :test do
   gem 'rdoc'
   gem 'database_cleaner'
 end
+
+
+group :development do
+  gem 'debugger'
+end

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -45,14 +45,14 @@ module Mongoid::Taggable
     end
 
     def tags
-      index_tags! if need_to_index_tags
+      index_tags_now! if need_to_index_tags and @do_tags_index
       tags_index_collection.find.sort(_id: 1).to_a.map{ |r| r["_id"]}
     end
 
     # retrieve the list of tags with weight (i.e. count), this is useful for
     # creating tag clouds
     def tags_with_weight
-      index_tags! if need_to_index_tags
+      index_tags_now! if need_to_index_tags and @do_tags_index
       tags_index_collection.find.sort(_id: 1).to_a.map{ |r| [r["_id"], r["matches"]] }
     end
 
@@ -87,13 +87,10 @@ module Mongoid::Taggable
       return unless @do_tags_index
 
       @need_to_index_tags = true
-   end
+    end
 
-    private
 
-    def index_tags!
-      return unless @do_tags_index
-
+    def index_tags_now!
       # tag indexing was incredibly slow using map_reduce
       # http://docs.mongodb.org/manual/core/map-reduce/ suggests using the aggregation pipeline
 

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -148,8 +148,6 @@ module Mongoid::Taggable
         {"$match" => {tags_array: {"$in" => total_tags} } }
       ]
 
-      related_pipeline.push({"$limit" => limit}) if  limit > 0
-
       related_pipeline = (pipeline_injection.kind_of?(Array) ?
                 related_pipeline.insert(0, *pipeline_injection)
               : related_pipeline.insert(0, pipeline_injection) )
@@ -178,7 +176,11 @@ module Mongoid::Taggable
         end
       end
 
-      self.find(related.map { |x| x["_id"] }).sort { |x,y| ordering[y.id] <=> ordering[x.id]  }
+      related = self.find(related.map { |x| x["_id"] }).sort { |x,y| ordering[y.id] <=> ordering[x.id] }
+      if limit > 0
+        return related.first(limit)
+      end
+      return related
     end
 
   end

--- a/mongoid_taggable.gemspec
+++ b/mongoid_taggable.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |g|
   g.name        = 'mongoid_taggable'
-  g.version     = '1.1.3'
+  g.version     = '1.1.4'
   g.date        = '2014-03-10'
   g.description = %q{Mongoid Taggable provides some helpers to create taggable documents.}
   g.summary     = %q{Mongoid taggable behaviour}

--- a/mongoid_taggable.gemspec
+++ b/mongoid_taggable.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |g|
   g.name        = 'mongoid_taggable'
-  g.version     = '1.1.2'
-  g.date        = '2014-03-07'
+  g.version     = '1.1.3'
+  g.date        = '2014-03-10'
   g.description = %q{Mongoid Taggable provides some helpers to create taggable documents.}
   g.summary     = %q{Mongoid taggable behaviour}
   g.authors     = ['Wilker Lucio', 'Kris Kowalik', 'Adam St. John', 'Caleb Clark']

--- a/mongoid_taggable.gemspec
+++ b/mongoid_taggable.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |g|
   g.name        = 'mongoid_taggable'
-  g.version     = '1.1.1'
-  g.date        = '2013-03-22'
+  g.version     = '1.1.2'
+  g.date        = '2014-03-07'
   g.description = %q{Mongoid Taggable provides some helpers to create taggable documents.}
   g.summary     = %q{Mongoid taggable behaviour}
   g.authors     = ['Wilker Lucio', 'Kris Kowalik', 'Adam St. John', 'Caleb Clark']

--- a/spec/mongoid/taggable_spec.rb
+++ b/spec/mongoid/taggable_spec.rb
@@ -224,11 +224,17 @@ describe Mongoid::Taggable do
       related.should include(@paul)
     end
 
-     it 'related items should be in order of similarity' do
+    it 'related items should be in order of similarity' do
       related = @paul.find_related
       related.should have_at_least(2).items
       related[0].should == @george
       related[1].should == @john
+    end
+
+    it 'should limit the results' do
+      related = @paul.find_related(1)
+      related.should have(1).items
+      related[0].should == @george
     end
 
     it 'should work with multiple items as input' do
@@ -250,6 +256,7 @@ describe Mongoid::Taggable do
       related.should have_at_least(1).items
       related[0].should == @someone_else2
     end
+
 
   end
 

--- a/spec/mongoid/taggable_spec.rb
+++ b/spec/mongoid/taggable_spec.rb
@@ -199,6 +199,61 @@ describe Mongoid::Taggable do
       m.save
     end
 
+
+
+
   end
+
+  context 'finding similarities based on tags' do
+
+    before :each do
+      @john = MyModel.create!({tags: 'a, b, c, d, e'})
+      @paul = MyModel.create!({tags: 'a, b, x, y, z'})
+      @george = MyModel.create!({tags: 'v, w, x, y, z'})
+      @ringo = MyModel.create!({tags: 'm, n, o, p, q'})
+    end
+
+
+    it 'should find a similar item based on tags' do
+      related = @john.find_related
+      expect(related).to be_kind_of(Array)
+      related.should have(1).items
+      related.should include(@paul)
+    end
+
+     it 'related items should be in order of similarity' do
+      related = @paul.find_related
+      expect(related).to be_kind_of(Array)
+      related.should have(2).items
+      expect(related[0]).to eq(@george)
+      expect(related[1]).to eq(@john)
+    end
+
+  end
+
+
+  context 'similarity finding speed' do
+    before :each do
+      MyModel.disable_tags_index!
+      @number_of_items = 10000
+      letters = ('a'..'z').to_a
+      @number_of_items.times do |x|
+        tags = letters.sample(2+rand(5))
+        #puts "#{x}: tags = #{tags}"
+        MyModel.create!({tags: tags.join(','), name: x.to_s})
+      end
+      MyModel.enable_tags_index!
+    end
+
+    it 'made tagged objects' do
+      MyModel.count.should eq(@number_of_items)
+    end
+
+
+  end
+
+
+
+
 
 end


### PR DESCRIPTION
Two major improvements:
1. Made indexing tags substantially faster:
2. Replaced map/reduce with Mongo aggregation. This makes finding the count of tags at least 10x faster.
3. Changed code so it only does the aggregation when it needs to. That is, it won't index tags on every document creation, just when there is a new document (or new tags), and the tag list is asked for.
4. Added "find related" ability based on how many tags match. This is easily limited, and you can inject your own filters before matching. You can find related based on a single document, or based on a series of documents.

I'm not sure if this project is stagnant. I hope it isn't. It would be nice to have a gem that supported most of what "acts_as_taggable_on" would do for Mongoid projects.
